### PR TITLE
Replace use of nightly features to allow building against stable rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,11 @@
 [package]
 name = "statsd_client"
-version = "0.1.1"
-authors = ["Julian Squires <julian@cipht.net>"]
+version = "0.2.0"
+authors = ["Julian Squires <julian@cipht.net>", "Francis Lalonde <francis.lalonde@adgear.com>"]
 publish = false
 
 [dependencies]
-nix = "0.8"
+time = "0.1"
+
+[features]
+bench = []

--- a/README.md
+++ b/README.md
@@ -1,17 +1,36 @@
-A Rust statsd client for fast-and-loose stats.
+trivial-statsd-client
+----
+A Rust statsd client for fast-and-loose metrics.
 
-Alternatives:
+## Alternatives:
  - https://github.com/tshlabs/cadence
  - https://github.com/markstory/rust-statsd
  - https://github.com/erik/rust-statsd
 
-Why this one?
- - tuned for heavily-sampled stats;
- - avoids floats at runtime wherever possible;
- - uses evil global state for the convenience of being able to drop a
-   `statsd!` macro anywhere (using the same approach as the log
-   crate).
-
-(This might not be true yet; this crate is in embryonic state and I
-think I'll have to do some procedural macro magic to get the effect I
-want.)
+## Why this one?
+ - supports subsampling (rate)
+ - avoids floats wherever possible
+ 
+## Testing it
+ 
+ Use `cargo test`, duh.
+ 
+ For manual integrated testing with a real local statsd server:
+ - Clone `https://github.com/etsy/statsd`
+ - Copy `exmapleConfig.js` to `config.js` and add the `dumpMessages: true,` directive
+ - Start the server `node stats.js config.js`
+ - Run the cargo tests
+ - See raw stats appear on statsd stdout 
+ 
+## To improve:
+ - Send multiple metrics per packet, either in explicit transaction or time+volume managed 
+ - Make sampling apply to group of operations (channel open / commit)
+ - Reuse packet-assembling string buffers **OR** 
+ - Use `iovec` crate + friend for scatter/ gather instead of copying to an intermediary strbuf  
+ - For lower sampling rates (< 1/256?), use predictive subsampling:
+    only call rng after every accepted sample to approximate next sample distance, 
+    then just inc a counter until we get there, sample, repeat
+    rng would fuzz around target rate according to some factor  
+    e.g. if rate is 1/2000, next sample would be between 1000 and 3000 points away
+    counter needs to be per metric or per channel to make sure samples are evenly distributed across metrics 
+ - Write more tests

--- a/src/pcg32.rs
+++ b/src/pcg32.rs
@@ -1,0 +1,29 @@
+/// PCG32 random number generation for fast sampling
+// TODO use https://github.com/codahale/pcg instead?
+use std::cell::RefCell;
+use time;
+
+fn seed() -> u64 {
+    let seed = 5573589319906701683_u64;
+    let seed = seed.wrapping_mul(6364136223846793005)
+        .wrapping_add(1442695040888963407)
+        .wrapping_add(time::precise_time_ns());
+    seed.wrapping_mul(6364136223846793005)
+        .wrapping_add(1442695040888963407)
+}
+
+pub fn random() -> u32 {
+    thread_local! {
+        static PCG32_STATE: RefCell<u64> = RefCell::new(seed());
+    }
+
+    PCG32_STATE.with(|state| {
+        let oldstate: u64 = *state.borrow();
+        // XXX could generate the increment from the thread ID
+        *state.borrow_mut() = oldstate.wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        ((((oldstate >> 18) ^ oldstate) >> 27) as u32)
+            .rotate_right((oldstate >> 59) as u32)
+    })
+}
+


### PR DESCRIPTION
Features affected:
 - Create no longer keeps a global shared statsd client. Client app now owns and passes the statsd client where required, and back to the
`statsd!` macro
 - pcg32 seeding uses plain `time::precise_time_ns()` instead of assembly accessing register
 - No longer passing 'branch likely skipped' hint to the compiler
 - libc sendfile(fd) replaced by std rust UdpSocket::send

Likely impacts:

Performance may decrease slightly but is not expected to be noticeable. In the absence of hard performance data, it is hard to justify the use of the removed features. If performance is revealed to be an issue, other methods may be tried as documented in the updated `README.md` file.

Ergonomics of the statsd! macro are suboptimal and could rely on thread locals for more than just rng. This should be the object of a future PR.